### PR TITLE
Fix bug with react-bootstrap version (WIP)

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/4Catalyzer/react-formal-bootstrap#readme",
   "peerDependencies": {
     "react": ">=0.14.0",
-    "react-bootstrap": ">= 0.29.0",
+    "react-bootstrap": "^0.29.0",
     "react-formal": "^0.24.3"
   },
   "devDependencies": {


### PR DESCRIPTION
React-bootstrap peer dependencies are matching with react-bootstrap 1.0.0-beta, which has breaking changes in it, breaking this. Unsure if this is the ideal matcher, but it should fix the problem (in theory, at least).